### PR TITLE
Add sketch for calibrating motor pwm values.

### DIFF
--- a/GetPwmValues/GetPwmValues.ino
+++ b/GetPwmValues/GetPwmValues.ino
@@ -1,0 +1,115 @@
+#include "calibration_functions.h"
+#include "menu_helpers.h"
+#include "motor.h"
+
+// create motor structure instances
+struct Motor leftMotor = { LEFTMOTORDIR, LEFTMOTORPWR };
+struct Motor rightMotor = { RIGHTMOTORDIR, RIGHTMOTORPWR };
+
+#define LEDPIN 7
+
+void blinkLed()
+{
+    pinMode(LEDPIN, OUTPUT);
+    int i;
+    for(i = 0; i < 10; i++) {
+        digitalWrite(LEDPIN, HIGH);
+        delay(100);
+        digitalWrite(LEDPIN, LOW);
+        delay(100);
+      }
+}
+void setup() {
+    blinkLed();
+    // put your setup code here, to run once:
+    Serial.begin(9600);
+    
+    // slow PWM frequency down
+    TCCR2B = TCCR2B & 0b1111100 | 0x02;
+    
+    motor_setup(leftMotor);
+    motor_setup(rightMotor);
+}
+
+void loop() {
+    int choice_array_length = 4;
+    
+    int motor_choices[4] = {'l','L','r','R'};
+    int direction_choices[4] = {'f','F','r','R'};
+    int min_max_choices[4] = {'u', 'U', 'l', 'L'};
+    
+    int motor_choice = 0;
+    int direction_choice = 0;
+    int min_max_choice = 0;
+    
+    motor_choice = prompt("Which motor to calibrate? [L(eft)/R(ight)]: ", motor_choices, choice_array_length);
+    direction_choice = prompt("Which direction to calibrate? [F(orward)/R(everse)]: ", direction_choices, choice_array_length);
+    min_max_choice = prompt("Calibrate upper or lower bound? [U(pper)/L(ower)]: ", min_max_choices, choice_array_length);
+    
+    // Left, Upper (Max), Forward
+    if ( ((motor_choice == '1') ||(motor_choice == 'L')) &&
+         ((min_max_choice == 'u') || (min_max_choice == 'U')) && 
+         ((direction_choice == 'f') || (direction_choice == 'F'))) {
+           calibrateMaxForward(leftMotor);
+    }
+    
+    // Left, Lower (Min), Forward
+    else if ( ((motor_choice == '1') || (motor_choice == 'L')) &&
+         ((min_max_choice == 'l') || (min_max_choice == 'L')) && 
+         ((direction_choice == 'f') || (direction_choice == 'F'))) {
+           calibrateMinForward(leftMotor);
+    }
+    
+    // Left, Upper (Max), Reverse
+    else if ( ((motor_choice == '1') || (motor_choice == 'L')) &&
+         ((min_max_choice == 'u') || (min_max_choice == 'U')) && 
+         ((direction_choice == 'r') || (direction_choice == 'R'))) {
+           calibrateMaxReverse(leftMotor);
+    }
+    
+    // Left, Lower (Min), Reverse
+    
+    else if ( ((motor_choice == '1') || (motor_choice == 'L')) &&
+         ((min_max_choice == 'l') || (min_max_choice == 'L')) && 
+         ((direction_choice == 'r') || (direction_choice == 'R'))) {
+           calibrateMinReverse(leftMotor);
+    }
+    
+    // Right, Upper (Max), Forward
+    else if ( ((motor_choice == 'r') || (motor_choice == 'R')) &&
+         ((min_max_choice == 'u') || (min_max_choice == 'U')) && 
+         ((direction_choice == 'f') || (direction_choice == 'F'))) {
+           calibrateMaxForward(rightMotor);
+    }
+    
+    // Right, Lower (Min), Forward
+    else if ( ((motor_choice == 'r') || (motor_choice == 'R')) &&
+         ((min_max_choice == 'l') || (min_max_choice == 'L')) && 
+         ((direction_choice == 'f') || (direction_choice == 'F'))) {
+           calibrateMinForward(rightMotor);
+    }
+    
+    // Right, Upper (Max), Reverse
+    else if ( ((motor_choice == 'r') || (motor_choice == 'R')) &&
+         ((min_max_choice == 'u') || (min_max_choice == 'U')) && 
+         ((direction_choice == 'r') || (direction_choice == 'R'))) {
+           calibrateMaxReverse(rightMotor);
+    }
+    
+    // Right, Lower (Min), Reverse
+    
+    else if ( ((motor_choice == 'r') || (motor_choice == 'R')) &&
+         ((min_max_choice == 'l') || (min_max_choice == 'L')) && 
+         ((direction_choice == 'r') || (direction_choice == 'R'))) {
+           calibrateMinReverse(rightMotor);
+    }
+    
+    else {
+        Serial.print("Invalid menu choices ");
+        Serial.print((char)motor_choice);
+        Serial.print(",");
+        Serial.print((char)direction_choice);
+        Serial.print(",");
+        Serial.println((char)min_max_choice);
+    }
+}

--- a/GetPwmValues/calibration_functions.cpp
+++ b/GetPwmValues/calibration_functions.cpp
@@ -1,0 +1,86 @@
+#include "calibration_functions.h"
+
+void calibrateMinForward(struct Motor motor)
+{
+    uint8_t hard_stop = FWD_OFF;
+    uint8_t stopped = FWD_OFF;
+    uint8_t distance = 255;
+    uint8_t last_yes = 0;
+    int valid_responses[4] = {'y','Y','n','N'};
+    int response_array_length = 4;
+    int response = 0;
+    uint8_t pwm_value;
+    digitalWrite(motor.dir_pin, FWDDIR);
+    do {
+        distance >>= 1; // divide by 2
+        pwm_value = stopped + distance;
+        analogWrite(motor.step_pin, pwm_value);
+        delay(1000);
+        analogWrite(motor.step_pin, hard_stop);
+        response = prompt("Did motor move? [Y(es)/N(o)]: ",valid_responses, response_array_length);
+        if (response == 'y' || response == 'Y') {
+            last_yes = pwm_value;
+        } else if (response == 'n' || response == 'N') {
+            stopped = pwm_value;
+        }
+        delay(1000);
+    } while (distance > 0);
+    
+    Serial.print("Pwm value: ");
+    Serial.println(last_yes);
+}
+
+void calibrateMaxForward(struct Motor motor)
+{
+    int i;
+    digitalWrite(motor.dir_pin, FWDDIR);
+    for (i = 128; i < 256; i++) {
+      Serial.print("Pwm value: ");
+      Serial.println(i);
+      analogWrite(motor.step_pin, i);
+      delay(1500);
+    }
+    analogWrite(motor.step_pin, 255);
+}
+
+void calibrateMinReverse(struct Motor motor)
+{
+    uint8_t hard_stop = REV_OFF;
+    uint8_t stopped = REV_OFF;
+    uint8_t distance = 255;
+    uint8_t last_yes = 0;
+    int valid_responses[4] = {'y','Y','n','N'};
+    int response_array_length = 4;
+    int response = 0;
+    uint8_t pwm_value;
+    digitalWrite(motor.dir_pin, REVDIR);
+    do {
+        distance >>= 1; // divide by 2
+        pwm_value = stopped - distance;
+        analogWrite(motor.step_pin, pwm_value);
+        delay(1000);
+        analogWrite(motor.step_pin, hard_stop);
+        response = prompt("Did motor move? [Y(es)/N(o)]: ",valid_responses, response_array_length);
+        if (response == 'y' || response == 'Y') {
+            last_yes = pwm_value;
+        } else if (response == 'n' || response == 'N') {
+            stopped = pwm_value;
+        }
+    } while (distance > 0);
+    
+    Serial.print("Pwm value: ");
+    Serial.println(last_yes);
+}
+
+void calibrateMaxReverse(struct Motor motor)
+{
+    int i;
+    digitalWrite(motor.dir_pin, REVDIR);
+    for (i = 128; i > -1; i--) {
+      Serial.print("Pwm value: ");
+      Serial.println(i);
+      analogWrite(motor.step_pin, i);
+      delay(1500);
+    }
+    analogWrite(motor.step_pin, 0);
+}

--- a/GetPwmValues/calibration_functions.h
+++ b/GetPwmValues/calibration_functions.h
@@ -1,0 +1,12 @@
+#ifndef _calibration_functions_h_
+#define _calibration_functions_h_
+#include "Arduino.h"
+#include "menu_helpers.h"
+#include "motor.h"
+
+void calibrateMinForward(struct Motor motor);
+void calibrateMaxForward(struct Motor motor);
+void calibrateMinReverse(struct Motor motor);
+void calibrateMaxReverse(struct Motor motor);
+
+#endif

--- a/GetPwmValues/menu_helpers.cpp
+++ b/GetPwmValues/menu_helpers.cpp
@@ -1,0 +1,21 @@
+#include "menu_helpers.h"
+int valid_response(int response, int* valid_answers, int array_len)
+{
+    int i;
+    for (i = 0; i < array_len; i++)
+        if (valid_answers[i] == response)
+            return 1; // found a valid response
+    return 0; // invalid response found          
+}
+
+char prompt(char* p, int* valid_answers, int array_len)
+{
+    char response;
+    do {
+        Serial.print(p);
+        while(!Serial.available() > 0); // wait for the user to input something
+        response = Serial.read(); // get input
+        Serial.println(response);
+    } while (valid_response(response, valid_answers, array_len) != 1);
+    return response;
+}

--- a/GetPwmValues/menu_helpers.h
+++ b/GetPwmValues/menu_helpers.h
@@ -1,0 +1,8 @@
+#ifndef _menu_helpers_h_
+#define _menu_helpers_h_
+#include "Arduino.h"
+
+int valid_response(int response, int* valid_answers, int array_len);
+char prompt(char* p, int* valid_answers, int array_len);
+
+#endif

--- a/GetPwmValues/motor.cpp
+++ b/GetPwmValues/motor.cpp
@@ -1,0 +1,8 @@
+#include "motor.h"
+
+void motor_setup(struct Motor motor)
+{
+    // here we configure pins for motor operation
+    pinMode(motor.dir_pin, OUTPUT);
+    pinMode(motor.step_pin,OUTPUT);
+}

--- a/GetPwmValues/motor.h
+++ b/GetPwmValues/motor.h
@@ -1,0 +1,30 @@
+#ifndef _motor_h_
+#define _motor_h_
+
+#include <stdint.h>
+#include "Arduino.h"
+
+// define some constants to represent pins
+#define LEFTMOTORDIR 12
+#define RIGHTMOTORDIR 13
+#define LEFTMOTORPWR 9
+#define RIGHTMOTORPWR 10
+
+#define FWD_FULL_ON 255
+#define FWD_OFF 0
+
+#define REV_FULL_ON FWD_OFF
+#define REV_OFF FWD_FULL_ON
+
+#define FWDDIR 0
+#define REVDIR 1
+
+// declare a structure to hold motor pin values
+struct Motor {
+    uint8_t dir_pin;
+    uint8_t step_pin;
+};
+
+void motor_setup(struct Motor motor);
+
+#endif


### PR DESCRIPTION
Just in case the motor full on and full off values are backwards:
(so if `FWD_FULL_ON = 0`, `FWD_OFF = 255`, `REV_FULL_ON = 255`, and `REV_OFF = 0`)

in `calibrateMinForward` change
`pwm_value = stopped + distance` to `pwm_value = stopped - distance`

in `calibrateMinReverse` change
`pwm_value = stopped - distance` to `pwm_value = stopped + distance`

in `calibrateMaxForward`
change the for loop to `for (i = 128; i >-1; i--)`

in `calibrateMaxReverse`
change the for loop to `for (i = 128; i < 256; i++)`

And of course, feel free to modify delays and the like, should they seem to short or too long.
The value of `i` in the for loops is arbitrary, you could start closer to the maximum for that direction to speed it up. I just didn't know where you started seeing the reset condition, so I picked an arbitrary number.
